### PR TITLE
fix: address CodeRabbit review comments

### DIFF
--- a/docker-mongo/Makefile
+++ b/docker-mongo/Makefile
@@ -23,7 +23,7 @@ logs:
 
 # Connect to the mongo shell
 connect:
-	docker exec -it $(CONTAINER_NAME) mongosh -u $(MONGO_USERNAME) -p $(MONGO_PASSWORD)
+	docker exec -it $(CONTAINER_NAME) mongosh -u $(MONGO_USERNAME) -p $(MONGO_PASSWORD) --authenticationDatabase admin
 
 # Show replica set status
 status:

--- a/docker-redis/Makefile
+++ b/docker-redis/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: build start connect run stop clean logs ps help
+.PHONY: start connect run stop clean logs ps help
 
 # Variables
 IMAGE_NAME = valkey/valkey:8
@@ -14,15 +14,14 @@ start:
 	@read -s VALKEY_PASSWORD; \
 	echo; \
 	echo "Starting Valkey container..."; \
-	grep -v "^requirepass" $(CONFIG_FILE) > $(CONFIG_FILE).tmp; \
-	if [ -n "$$VALKEY_PASSWORD" ]; then echo "requirepass $$VALKEY_PASSWORD" >> $(CONFIG_FILE).tmp; fi; \
-	mv $(CONFIG_FILE).tmp $(CONFIG_FILE); \
+	PASS_FLAG=""; \
+	if [ -n "$$VALKEY_PASSWORD" ]; then PASS_FLAG="--requirepass $$VALKEY_PASSWORD"; fi; \
 	docker run -d \
 	  --name $(CONTAINER_NAME) \
 	  -p $(PORT):$(PORT) \
 	  -v $(VOLUME_NAME):/data \
 	  -v $(CURDIR)/$(CONFIG_FILE):/etc/valkey/valkey.conf \
-	  $(IMAGE_NAME) valkey-server /etc/valkey/valkey.conf && \
+	  $(IMAGE_NAME) valkey-server /etc/valkey/valkey.conf $$PASS_FLAG && \
 	echo "Valkey started on port $(PORT)"
 
 # Connect to the Valkey server using valkey-cli

--- a/docker-redis/Makefile
+++ b/docker-redis/Makefile
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+.PHONY: build start connect run stop clean logs ps help
+
 # Variables
 IMAGE_NAME = valkey/valkey:8
 CONTAINER_NAME = valkey-container
@@ -9,15 +12,17 @@ CONFIG_FILE = redis.conf
 start:
 	@echo "Enter Valkey password (press Enter for no password):"
 	@read -s VALKEY_PASSWORD; \
+	echo; \
 	echo "Starting Valkey container..."; \
-	PASS_FLAG=""; \
-	if [ -n "$$VALKEY_PASSWORD" ]; then PASS_FLAG="--requirepass $$VALKEY_PASSWORD"; fi; \
+	grep -v "^requirepass" $(CONFIG_FILE) > $(CONFIG_FILE).tmp; \
+	if [ -n "$$VALKEY_PASSWORD" ]; then echo "requirepass $$VALKEY_PASSWORD" >> $(CONFIG_FILE).tmp; fi; \
+	mv $(CONFIG_FILE).tmp $(CONFIG_FILE); \
 	docker run -d \
 	  --name $(CONTAINER_NAME) \
 	  -p $(PORT):$(PORT) \
 	  -v $(VOLUME_NAME):/data \
 	  -v $(CURDIR)/$(CONFIG_FILE):/etc/valkey/valkey.conf \
-	  $(IMAGE_NAME) valkey-server /etc/valkey/valkey.conf $$PASS_FLAG && \
+	  $(IMAGE_NAME) valkey-server /etc/valkey/valkey.conf && \
 	echo "Valkey started on port $(PORT)"
 
 # Connect to the Valkey server using valkey-cli


### PR DESCRIPTION
- Add --authenticationDatabase admin to mongo connect target for consistency with status target
- Add SHELL := /bin/bash to ensure read -s works correctly in Valkey Makefile
- Add .PHONY declarations for all task targets in Valkey Makefile
- Write password into config file instead of passing via CLI arg to avoid secret exposure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MongoDB container authentication updated to align connections with the admin database.
  * Minor UX tweak in Redis container startup to improve password prompt spacing.

* **New Features**
  * Redis container Makefile exposes additional management targets (start, stop, logs, etc.) and standardizes the shell environment for smoother CLI use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->